### PR TITLE
Add Java module info for each module

### DIFF
--- a/adapter-input-handler/src/main/java/module-info.java
+++ b/adapter-input-handler/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module hex.basic.adapter.input.handler {
+    exports com.jdriven.adapters.inputhandler to hex.basic.app;
+    requires org.slf4j;
+    requires hex.basic.core;
+}

--- a/adapter-persistence/src/main/java/module-info.java
+++ b/adapter-persistence/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module hex.basic.adapter.persistence {
+    exports com.jdriven.adapters.persistence to hex.basic.app;
+    requires hex.basic.core;
+    requires org.slf4j;
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,8 @@ tasks.test {
 }
 
 application {
+    // Define module
+    mainModule.set("hex.basic.app")
     // Define the main class for the application.
     mainClass.set("com.jdriven.app.App")
 }

--- a/app/src/main/java/module-info.java
+++ b/app/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module hex.basic.app {
+    requires org.slf4j;
+    requires hex.basic.core;
+    requires hex.basic.adapter.input.handler;
+    requires hex.basic.adapter.persistence;
+}

--- a/buildSrc/src/main/kotlin/shared-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/shared-config.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
 java {
     sourceCompatibility = JavaVersion.VERSION_14
     targetCompatibility = JavaVersion.VERSION_14
+    modularity.inferModulePath.set(true)
 }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module hex.basic.core {
+    exports com.jdriven.domain.models to hex.basic.adapter.input.handler, hex.basic.adapter.persistence;
+    exports com.jdriven.domain.ports to hex.basic.adapter.input.handler, hex.basic.adapter.persistence, hex.basic.app;
+    exports com.jdriven.domain.services to hex.basic.app;
+    requires org.slf4j;
+}


### PR DESCRIPTION
Added Java modules and enabled Gradle's support for Java modules.
Nice to play with in IntelliJ by removing lines from module-info.java and see how IntelliJ shows how classes are not visible anymore.